### PR TITLE
学歴の直下に資格欄を移動

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,12 +57,12 @@
       <!-- Navigation Header -->
       <nav class="main-nav" data-aos="fade-down">
         <ul class="nav-list">
+          <li><a href="#certifications">資格</a></li>
           <li><a href="#research">研究内容</a></li>
           <li><a href="#experience">実務経験</a></li>
           <li><a href="#projects">制作物</a></li>
           <li><a href="#activities">学生団体</a></li>
           <li><a href="#awards">受賞歴</a></li>
-          <li><a href="#certifications">資格</a></li>
           <li><a href="#media">メディア</a></li>
         </ul>
       </nav>
@@ -124,6 +124,20 @@
           </div>
         </div>
       </div>
+
+      <section id="certifications" class="content-block" data-aos="fade-up">
+        <h2>資格</h2>
+        <ul class="qualifications-list">
+          <li class="qualification-item">
+            <strong>TOEIC L&R 800</strong>
+            <p>Test of English for International Communication (Listening & Reading)</p>
+          </li>
+          <li class="qualification-item">
+            <strong>第一種普通自動二輪車免許</strong>
+            <p>普通自動二輪車運転免許（400cc以下）</p>
+          </li>
+        </ul>
+      </section>
 
       <section id="research" class="content-block" data-aos="fade-up">
         <h2><i class="fas fa-flask"></i> 研究内容</h2>
@@ -311,20 +325,6 @@
         </ul>
       </section>
 
-      <section id="certifications" class="content-block" data-aos="fade-up">
-        <h2>資格</h2>
-        <ul class="qualifications-list">
-          <li class="qualification-item">
-            <strong>TOEIC L&R 800</strong>
-            <p>Test of English for International Communication (Listening & Reading)</p>
-          </li>
-          <li class="qualification-item">
-            <strong>第一種普通自動二輪車免許</strong>
-            <p>普通自動二輪車運転免許（400cc以下）</p>
-          </li>
-        </ul>
-      </section>
-
       <section id="media" class="content-block" data-aos="fade-up">
         <h2><i class="fas fa-tv"></i> メディア出演歴</h2>
         <ul class="media-list">
@@ -381,12 +381,12 @@
       <!-- Navigation Header -->
       <nav class="main-nav" data-aos="fade-down">
         <ul class="nav-list">
+          <li><a href="#certifications">Certifications</a></li>
           <li><a href="#research">Research</a></li>
           <li><a href="#experience">Experience</a></li>
           <li><a href="#projects">Projects</a></li>
           <li><a href="#activities">Leadership</a></li>
           <li><a href="#awards">Awards</a></li>
-          <li><a href="#certifications">Certifications</a></li>
           <li><a href="#media">Media</a></li>
           <li><a href="#skills">Skills</a></li>
         </ul>
@@ -449,6 +449,20 @@
           </div>
         </div>
       </div>
+
+      <section id="certifications" class="content-block" data-aos="fade-up">
+        <h2>Certifications</h2>
+        <ul class="qualifications-list">
+          <li class="qualification-item">
+            <strong>TOEIC L&R 800</strong>
+            <p>Test of English for International Communication (Listening & Reading)</p>
+          </li>
+          <li class="qualification-item">
+            <strong>Ordinary Motorcycle License (Class 1)</strong>
+            <p>Regular motorcycle license (up to 400cc)</p>
+          </li>
+        </ul>
+      </section>
 
       <section id="research" class="content-block" data-aos="fade-up">
         <h2><i class="fas fa-flask"></i> Research</h2>
@@ -591,20 +605,6 @@
           <li class="award-item">
             <strong>10tan Inc. Core Values Award</strong>
             <p>Recognized for embodying the principle that "Work is not something given to you, but something you create. However, this doesn't mean doing things aimlessly. It's important to think deeply about 'WHY' and then determine what is needed and what should be done, before taking action."</p>
-          </li>
-        </ul>
-      </section>
-
-      <section id="certifications" class="content-block" data-aos="fade-up">
-        <h2>Certifications</h2>
-        <ul class="qualifications-list">
-          <li class="qualification-item">
-            <strong>TOEIC L&R 800</strong>
-            <p>Test of English for International Communication (Listening & Reading)</p>
-          </li>
-          <li class="qualification-item">
-            <strong>Ordinary Motorcycle License (Class 1)</strong>
-            <p>Regular motorcycle license (up to 400cc)</p>
           </li>
         </ul>
       </section>


### PR DESCRIPTION
## Summary
- 訪問者がプロフィールを手早く把握できるよう、資格セクションを学歴の真下へ移動
- ナビゲーションの順序も合わせて更新（資格を先頭に）
- 日本語版・英語版の両方を対応

## Test plan
- [ ] index.html を開き、学歴のすぐ下に資格欄が表示されることを確認
- [ ] ナビゲーションの「資格 / Certifications」リンクが正しく該当セクションへスクロールすること
- [ ] 言語切替後も同じ並び順になっていること

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3gKa6c9hrGhCMryjF9W4q)_